### PR TITLE
Upgrade pinot server segment level query client and add Pinot server grpc client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,8 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <shadeBase>org.apache.pinot.\$internal</shadeBase>
-        <dep.pinot.version>0.1.0</dep.pinot.version>
+        <dep.pinot.version>0.5.0</dep.pinot.version>
+        <dep.helix.version>0.9.7</dep.helix.version>
         <log4j.version>2.11.2</log4j.version>
     </properties>
 
@@ -59,25 +60,87 @@
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>4.1.42.Final</version>
-        </dependency>
-
-        <dependency>
-            <!-- pinot-common depends on this but does not include it -->
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.5</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
             <!-- To avoid the warning that the antlr runtime version differs -->
             <version>4.6</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.pinot</groupId>
+            <artifactId>pinot-spi</artifactId>
+            <version>${dep.pinot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.antlr</groupId>
+                    <artifactId>antlr4-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>it.unimi.dsi</groupId>
+                    <artifactId>fastutil</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka_2.10</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.apache.pinot</groupId>
             <artifactId>pinot-common</artifactId>
@@ -155,53 +218,25 @@
                     <groupId>jakarta.annotation</groupId>
                     <artifactId>jakarta.annotation-api</artifactId>
                 </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.pinot</groupId>
-            <artifactId>pinot-transport</artifactId>
-            <version>${dep.pinot.version}</version>
-            <exclusions>
                 <exclusion>
-                    <groupId>org.checkerframework</groupId>
-                    <artifactId>checker-compat-qual</artifactId>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.antlr</groupId>
-                    <artifactId>antlr4-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka-clients</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka_2.10</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.validation</groupId>
-                    <artifactId>validation-api</artifactId>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -218,6 +253,10 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -255,33 +294,139 @@
                     <groupId>javax.validation</groupId>
                     <artifactId>validation-api</artifactId>
                 </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libthrift</artifactId>
-            <version>0.12.0</version>
-            <exclusions>
                 <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpcore</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-analyzers-common</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
 
         <dependency>
+            <groupId>org.apache.helix</groupId>
+            <artifactId>helix-core</artifactId>
+            <version>${dep.helix.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.antlr</groupId>
+                    <artifactId>antlr4-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>it.unimi.dsi</groupId>
+                    <artifactId>fastutil</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka_2.10</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.yammer.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+            <version>1.30.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.12.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 
@@ -324,19 +469,21 @@
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                             <artifactSet>
                                 <includes>
-                                    <include>org.apache.pinot:*</include>
                                     <include>com.google.guava:*</include>
-                                    <include>org.apache.commons:*</include>
+                                    <include>com.google.protobuf:*</include>
+                                    <include>com.yammer.metrics:*</include>
                                     <include>commons-*:*</include>
+                                    <include>io.grpc:*</include>
+                                    <include>io.netty:*</include>
+                                    <include>org.apache.commons:*</include>
+                                    <include>org.apache.pinot:*</include>
                                     <include>org.apache.http:*</include>
                                     <include>org.antlr:*</include>
-                                    <include>io.netty:*</include>
                                     <include>org.apache.thrift:*</include>
-                                    <include>com.yammer.metrics:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
-                                <!-- everything except the stuff in pinot-common is shaded -->
+                                <!-- everything except the stuff in pinot-spi, pinot-common is shaded -->
                                 <relocation>
                                     <pattern>org.apache.pinot.pql</pattern>
                                     <shadedPattern>${shadeBase}.org.apache.pinot.pql</shadedPattern>
@@ -356,10 +503,6 @@
                                 <relocation>
                                     <pattern>org.apache.http</pattern>
                                     <shadedPattern>${shadeBase}.org.apache.http</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.pinot.transport</pattern>
-                                    <shadedPattern>${shadeBase}.org.apache.pinot.transport</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.pinot.core</pattern>

--- a/src/main/java/com/facebook/presto/pinot/PinotScatterGatherQueryClient.java
+++ b/src/main/java/com/facebook/presto/pinot/PinotScatterGatherQueryClient.java
@@ -14,40 +14,29 @@
 package com.facebook.presto.pinot;
 
 import com.yammer.metrics.core.MetricsRegistry;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.HashedWheelTimer;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.request.InstanceRequest;
-import org.apache.pinot.common.response.ServerInstance;
 import org.apache.pinot.common.utils.DataTable;
-import org.apache.pinot.core.common.datatable.DataTableFactory;
+import org.apache.pinot.core.transport.AsyncQueryResponse;
+import org.apache.pinot.core.transport.QueryRouter;
+import org.apache.pinot.core.transport.ServerResponse;
+import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
-import org.apache.pinot.serde.SerDe;
-import org.apache.pinot.transport.common.CompositeFuture;
-import org.apache.pinot.transport.metrics.NettyClientMetrics;
-import org.apache.pinot.transport.netty.PooledNettyClientResourceManager;
-import org.apache.pinot.transport.pool.KeyedPool;
-import org.apache.pinot.transport.pool.KeyedPoolImpl;
-import org.apache.pinot.transport.scattergather.ScatterGather;
-import org.apache.pinot.transport.scattergather.ScatterGatherImpl;
-import org.apache.pinot.transport.scattergather.ScatterGatherRequest;
-import org.apache.pinot.transport.scattergather.ScatterGatherStats;
-import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static java.lang.String.format;
@@ -55,18 +44,21 @@ import static java.lang.String.format;
 public class PinotScatterGatherQueryClient
 {
     private static final Pql2Compiler REQUEST_COMPILER = new Pql2Compiler();
-    private static final String PRESTO_HOST_PREFIX = "presto-pinot-master";
+    private static final String PRESTO_HOST_PREFIX = "presto-pinot-";
     private static final boolean DEFAULT_EMIT_TABLE_LEVEL_METRICS = true;
 
     private final String prestoHostId;
     private final BrokerMetrics brokerMetrics;
-    private final ScatterGather scatterGatherer;
+    private final Queue<QueryRouter> queryRouters = new ConcurrentLinkedQueue<>();
+    private final Config config;
+    private final Map<String, AtomicInteger> concurrentQueriesCountMap = new ConcurrentHashMap<>();
 
     public enum ErrorCode
     {
         PINOT_INSUFFICIENT_SERVER_RESPONSE(true),
         PINOT_INVALID_PQL_GENERATED(false),
-        PINOT_UNCLASSIFIED_ERROR(false);
+        PINOT_UNCLASSIFIED_ERROR(false),
+        PINOT_QUERY_BACKLOG_FULL(false);
 
         private final boolean retriable;
 
@@ -105,13 +97,19 @@ public class PinotScatterGatherQueryClient
 
     public static class Config
     {
-        private final long idleTimeoutMillis;
         private final int threadPoolSize;
-        private final int minConnectionsPerServer;
+
         private final int maxBacklogPerServer;
+
+        @Deprecated
+        private final long idleTimeoutMillis;
+        @Deprecated
+        private final int minConnectionsPerServer;
+        @Deprecated
         private final int maxConnectionsPerServer;
 
-        public Config(long idleTimeoutMillis, int threadPoolSize, int minConnectionsPerServer, int maxBacklogPerServer, int maxConnectionsPerServer)
+        public Config(long idleTimeoutMillis, int threadPoolSize, int minConnectionsPerServer, int maxBacklogPerServer,
+                      int maxConnectionsPerServer)
         {
             this.idleTimeoutMillis = idleTimeoutMillis;
             this.threadPoolSize = threadPoolSize;
@@ -120,19 +118,9 @@ public class PinotScatterGatherQueryClient
             this.maxConnectionsPerServer = maxConnectionsPerServer;
         }
 
-        public long getIdleTimeoutMillis()
-        {
-            return idleTimeoutMillis;
-        }
-
         public int getThreadPoolSize()
         {
             return threadPoolSize;
-        }
-
-        public int getMinConnectionsPerServer()
-        {
-            return minConnectionsPerServer;
         }
 
         public int getMaxBacklogPerServer()
@@ -140,6 +128,19 @@ public class PinotScatterGatherQueryClient
             return maxBacklogPerServer;
         }
 
+        @Deprecated
+        public long getIdleTimeoutMillis()
+        {
+            return idleTimeoutMillis;
+        }
+
+        @Deprecated
+        public int getMinConnectionsPerServer()
+        {
+            return minConnectionsPerServer;
+        }
+
+        @Deprecated
         public int getMaxConnectionsPerServer()
         {
             return maxConnectionsPerServer;
@@ -154,18 +155,12 @@ public class PinotScatterGatherQueryClient
         brokerMetrics = new BrokerMetrics(registry, DEFAULT_EMIT_TABLE_LEVEL_METRICS);
         brokerMetrics.initializeGlobalMeters();
 
-        final NettyClientMetrics clientMetrics = new NettyClientMetrics(registry, "presto_pinot_client_");
+        // Setup QueryRouters
+        for (int i = 0; i < pinotConfig.getThreadPoolSize(); i++) {
+            queryRouters.add(new QueryRouter(String.format("%s-%d", prestoHostId, i), brokerMetrics));
+        }
 
-        // Setup Netty Connection Pool
-        PooledNettyClientResourceManager resourceManager = new PooledNettyClientResourceManager(new NioEventLoopGroup(), new HashedWheelTimer(), clientMetrics);
-        ExecutorService requestSenderPool = Executors.newFixedThreadPool(pinotConfig.getThreadPoolSize());
-        ScheduledThreadPoolExecutor poolTimeoutExecutor = new ScheduledThreadPoolExecutor(50);
-        KeyedPool<PooledNettyClientResourceManager.PooledClientConnection> connPool = new KeyedPoolImpl<>(pinotConfig.getMinConnectionsPerServer(), pinotConfig.getMaxConnectionsPerServer(), pinotConfig.getIdleTimeoutMillis(),
-                pinotConfig.getMaxBacklogPerServer(), resourceManager, poolTimeoutExecutor, requestSenderPool, registry);
-        resourceManager.setPool(connPool);
-
-        // Setup ScatterGather
-        scatterGatherer = new ScatterGatherImpl(connPool, requestSenderPool);
+        config = pinotConfig;
     }
 
     private static <T> T doWithRetries(int retries, Function<Integer, T> caller)
@@ -199,165 +194,101 @@ public class PinotScatterGatherQueryClient
         return defaultBrokerId;
     }
 
-    public Map<ServerInstance, DataTable> queryPinotServerForDataTable(String pql, String serverHost, List<String> segments, long connectionTimeoutInMillis, boolean ignoreEmptyResponses, int pinotRetryCount)
+    public Map<ServerInstance, DataTable> queryPinotServerForDataTable(
+            String pql,
+            String serverHost,
+            List<String> segments,
+            long connectionTimeoutInMillis,
+            boolean ignoreEmptyResponses,
+            int pinotRetryCount)
     {
         BrokerRequest brokerRequest;
         try {
             brokerRequest = REQUEST_COMPILER.compileToBrokerRequest(pql);
         }
         catch (Pql2CompilationException e) {
-            throw new PinotException(ErrorCode.PINOT_INVALID_PQL_GENERATED, format("Parsing error with on %s, Error = %s", serverHost, e.getMessage()), e);
+            throw new PinotException(ErrorCode.PINOT_INVALID_PQL_GENERATED,
+                    format("Parsing error with on %s, Error = %s", serverHost, e.getMessage()), e);
         }
 
-        Map<String, List<String>> routingTable = new HashMap<>();
-        routingTable.put(serverHost, new ArrayList<>(segments));
+        Map<org.apache.pinot.core.transport.ServerInstance, List<String>> routingTable = new HashMap<>();
+        routingTable.put(new org.apache.pinot.core.transport.ServerInstance(new InstanceConfig(serverHost)), new ArrayList<>(segments));
 
         // Unfortunately the retries will all hit the same server because the routing decision has already been made by the pinot broker
-        Map<ServerInstance, byte[]> serverResponseMap = doWithRetries(pinotRetryCount, (requestId) -> {
-            ScatterGatherRequest scatterRequest = new ScatterGatherRequestWrapper(brokerRequest, routingTable, requestId, connectionTimeoutInMillis, prestoHostId);
-
-            ScatterGatherStats scatterGatherStats = new ScatterGatherStats();
-            CompositeFuture<byte[]> compositeFuture = routeScatterGather(scatterRequest, scatterGatherStats);
-            return gatherServerResponses(ignoreEmptyResponses, routingTable, compositeFuture, brokerRequest.getQuerySource().getTableName());
+        Map<ServerInstance, DataTable> serverResponseMap = doWithRetries(pinotRetryCount, (requestId) -> {
+            String rawTableName = TableNameBuilder.extractRawTableName(brokerRequest.getQuerySource().getTableName());
+            if (!concurrentQueriesCountMap.containsKey(serverHost)) {
+                concurrentQueriesCountMap.put(serverHost, new AtomicInteger(0));
+            }
+            int concurrentQueryNum = concurrentQueriesCountMap.get(serverHost).get();
+            if (concurrentQueryNum > config.getMaxBacklogPerServer()) {
+                throw new PinotException(ErrorCode.PINOT_QUERY_BACKLOG_FULL, "Reaching server query max backlog size is - " + config.getMaxBacklogPerServer());
+            }
+            concurrentQueriesCountMap.get(serverHost).incrementAndGet();
+            AsyncQueryResponse asyncQueryResponse;
+            QueryRouter nextAvailableQueryRouter = getNextAvailableQueryRouter();
+            if (TableNameBuilder.getTableTypeFromTableName(brokerRequest.getQuerySource().getTableName())
+                    == TableType.REALTIME) {
+                asyncQueryResponse = nextAvailableQueryRouter.submitQuery(requestId, rawTableName, null, null, brokerRequest, routingTable, connectionTimeoutInMillis);
+            }
+            else {
+                asyncQueryResponse = nextAvailableQueryRouter
+                        .submitQuery(requestId, rawTableName, brokerRequest, routingTable, null, null, connectionTimeoutInMillis);
+            }
+            Map<ServerInstance, DataTable> serverInstanceDataTableMap = gatherServerResponses(
+                    ignoreEmptyResponses,
+                    routingTable,
+                    asyncQueryResponse,
+                    brokerRequest.getQuerySource().getTableName());
+            queryRouters.offer(nextAvailableQueryRouter);
+            concurrentQueriesCountMap.get(serverHost).decrementAndGet();
+            return serverInstanceDataTableMap;
         });
-        return deserializeServerResponses(serverResponseMap, brokerRequest.getQuerySource().getTableName());
+        return serverResponseMap;
     }
 
-    private Map<ServerInstance, byte[]> gatherServerResponses(
-            boolean ignoreEmptyResponses,
-            Map<String, List<String>> routingTable,
-            CompositeFuture<byte[]> compositeFuture,
-            String tableNameWithType)
+    private QueryRouter getNextAvailableQueryRouter()
+    {
+        QueryRouter queryRouter = queryRouters.poll();
+        while (queryRouter == null) {
+            try {
+                Thread.sleep(200L);
+            }
+            catch (InterruptedException e) {
+                // Swallow the exception
+            }
+            queryRouter = queryRouters.poll();
+        }
+        return queryRouter;
+    }
+
+    private Map<ServerInstance, DataTable> gatherServerResponses(boolean ignoreEmptyResponses,
+                                                                 Map<org.apache.pinot.core.transport.ServerInstance, List<String>> routingTable, AsyncQueryResponse asyncQueryResponse, String tableNameWithType)
     {
         try {
-            Map<ServerInstance, byte[]> serverResponseMap = compositeFuture.get();
+            Map<ServerRoutingInstance, ServerResponse> queryResponses = asyncQueryResponse.getResponse();
             if (!ignoreEmptyResponses) {
-                if (serverResponseMap.size() != routingTable.size()) {
+                if (queryResponses.size() != routingTable.size()) {
                     Map<String, String> routingTableForLogging = new HashMap<>();
                     routingTable.entrySet().forEach(entry -> {
-                        String valueToPrint = entry.getValue().size() > 10 ? format("%d segments", entry.getValue().size()) : entry.getValue().toString();
-                        routingTableForLogging.put(entry.getKey(), valueToPrint);
+                        String valueToPrint = entry.getValue().size() > 10 ? format("%d segments", entry.getValue().size())
+                                : entry.getValue().toString();
+                        routingTableForLogging.put(entry.getKey().toString(), valueToPrint);
                     });
-                    throw new PinotException(ErrorCode.PINOT_INSUFFICIENT_SERVER_RESPONSE, String.format("%d of %d servers responded with routing table servers: %s, error: %s", serverResponseMap.size(), routingTable.size(), routingTableForLogging, compositeFuture.getError()));
-                }
-                for (Map.Entry<ServerInstance, byte[]> entry : serverResponseMap.entrySet()) {
-                    if (entry.getValue().length == 0) {
-                        throw new PinotException(ErrorCode.PINOT_INSUFFICIENT_SERVER_RESPONSE, String.format("Got empty response with from server: %s", entry.getKey().getShortHostName()));
-                    }
+                    throw new PinotException(ErrorCode.PINOT_INSUFFICIENT_SERVER_RESPONSE, String
+                            .format("%d of %d servers responded with routing table servers: %s, query stats: %s",
+                                    queryResponses.size(), routingTable.size(), routingTableForLogging, asyncQueryResponse.getStats()));
                 }
             }
+            Map<ServerInstance, DataTable> serverResponseMap = new HashMap<>();
+            queryResponses.entrySet().forEach(entry -> serverResponseMap.put(
+                    new ServerInstance(new org.apache.pinot.core.transport.ServerInstance(new InstanceConfig(String.format("Server_%s_%d", entry.getKey().getHostname(), entry.getKey().getPort())))),
+                    entry.getValue().getDataTable()));
             return serverResponseMap;
         }
-        catch (ExecutionException | InterruptedException e) {
-            Throwable err = e instanceof ExecutionException ? e.getCause() : e;
-            throw new PinotException(ErrorCode.PINOT_UNCLASSIFIED_ERROR, String.format("Caught exception while fetching responses for table: %s", tableNameWithType), err);
-        }
-    }
-
-    /**
-     * Deserialize the server responses, put the de-serialized data table into the data table map passed in, append
-     * processing exceptions to the processing exception list passed in.
-     * <p>For hybrid use case, multiple responses might be from the same instance. Use response sequence to distinguish
-     * them.
-     *
-     * @param responseMap map from server to response.
-     * @param tableNameWithType table name with type suffix.
-     * @return dataTableMap map from server to data table.
-     */
-    private Map<ServerInstance, DataTable> deserializeServerResponses(
-            Map<ServerInstance, byte[]> responseMap,
-            String tableNameWithType)
-    {
-        Map<ServerInstance, DataTable> dataTableMap = new HashMap<>();
-        for (Map.Entry<ServerInstance, byte[]> entry : responseMap.entrySet()) {
-            ServerInstance serverInstance = entry.getKey();
-            byte[] value = entry.getValue();
-            if (value == null || value.length == 0) {
-                continue;
-            }
-            try {
-                dataTableMap.put(serverInstance, DataTableFactory.getDataTable(value));
-            }
-            catch (IOException e) {
-                throw new PinotException(ErrorCode.PINOT_UNCLASSIFIED_ERROR, String.format("Caught exceptions while deserializing response for table: %s from server: %s", tableNameWithType, serverInstance), e);
-            }
-        }
-        return dataTableMap;
-    }
-
-    private CompositeFuture<byte[]> routeScatterGather(ScatterGatherRequest scatterRequest, ScatterGatherStats scatterGatherStats)
-    {
-        try {
-            return this.scatterGatherer.scatterGather(scatterRequest, scatterGatherStats, true, brokerMetrics);
-        }
         catch (InterruptedException e) {
-            throw new PinotException(ErrorCode.PINOT_UNCLASSIFIED_ERROR, format("Interrupted while sending request: %s", scatterRequest), e);
-        }
-    }
-
-    private static class ScatterGatherRequestWrapper
-            implements ScatterGatherRequest
-    {
-        private final BrokerRequest brokerRequest;
-        private final Map<String, List<String>> routingTable;
-        private final long requestId;
-        private final long requestTimeoutMs;
-        private final String brokerId;
-
-        public ScatterGatherRequestWrapper(BrokerRequest request, Map<String, List<String>> routingTable, long requestId, long requestTimeoutMs, String brokerId)
-        {
-            brokerRequest = request;
-            this.routingTable = routingTable;
-            this.requestId = requestId;
-
-            this.requestTimeoutMs = requestTimeoutMs;
-            this.brokerId = brokerId;
-        }
-
-        @Override
-        public Map<String, List<String>> getRoutingTable()
-        {
-            return routingTable;
-        }
-
-        @Override
-        public byte[] getRequestForService(List<String> segments)
-        {
-            InstanceRequest request = new InstanceRequest();
-            request.setRequestId(requestId);
-            request.setEnableTrace(brokerRequest.isEnableTrace());
-            request.setQuery(brokerRequest);
-            request.setSearchSegments(segments);
-            request.setBrokerId(brokerId);
-            return new SerDe(new TCompactProtocol.Factory()).serialize(request);
-        }
-
-        @Override
-        public long getRequestId()
-        {
-            return requestId;
-        }
-
-        @Override
-        public long getRequestTimeoutMs()
-        {
-            return requestTimeoutMs;
-        }
-
-        @Override
-        public BrokerRequest getBrokerRequest()
-        {
-            return brokerRequest;
-        }
-
-        @Override
-        public String toString()
-        {
-            if (routingTable == null) {
-                return null;
-            }
-
-            return Arrays.toString(routingTable.entrySet().toArray());
+            throw new PinotException(ErrorCode.PINOT_UNCLASSIFIED_ERROR,
+                    String.format("Caught exception while fetching responses for table: %s", tableNameWithType), e);
         }
     }
 }

--- a/src/main/java/com/facebook/presto/pinot/ServerInstance.java
+++ b/src/main/java/com/facebook/presto/pinot/ServerInstance.java
@@ -1,0 +1,74 @@
+package com.facebook.presto.pinot;
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.helix.model.InstanceConfig;
+
+/**
+ * Since `pinot-core` module is shaded, `org.apache.pinot.core.transport.ServerInstance` won't be exposed to external usage.
+ * So we provide a wrapper class to expose same APIs as `org.apache.pinot.core.transport.ServerInstance`.
+ *
+ */
+public class ServerInstance
+{
+    private final org.apache.pinot.core.transport.ServerInstance serverInstance;
+
+    public ServerInstance(org.apache.pinot.core.transport.ServerInstance serverInstance)
+    {
+        this.serverInstance = serverInstance;
+    }
+
+    public ServerInstance(String serverInstance)
+    {
+        this.serverInstance = new org.apache.pinot.core.transport.ServerInstance(new InstanceConfig(serverInstance));
+    }
+
+    public String getHostname()
+    {
+        return serverInstance.getHostname();
+    }
+
+    public int getPort()
+    {
+        return serverInstance.getPort();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return serverInstance.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof ServerInstance) {
+            ServerInstance that = (ServerInstance) obj;
+            return getHostname().equals(that.getHostname()) && getPort() == that.getPort();
+        }
+        return false;
+    }
+
+    /**
+     * Use default format {@code Server_<hostname>_<port>} for backward-compatibility.
+     */
+    @Override
+    public String toString()
+    {
+        return serverInstance.toString();
+    }
+}

--- a/src/main/java/com/facebook/presto/pinot/grpc/Constants.java
+++ b/src/main/java/com/facebook/presto/pinot/grpc/Constants.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot.grpc;
+
+/**
+ * Common constants defined in `org.apache.pinot.common.utils.CommonConstants` from Pinot common 0.6.0
+ */
+public class Constants
+{
+    public static class Request
+    {
+        public static class MetadataKeys
+        {
+            public static final String REQUEST_ID = "requestId";
+            public static final String BROKER_ID = "brokerId";
+            public static final String ENABLE_TRACE = "enableTrace";
+            public static final String ENABLE_STREAMING = "enableStreaming";
+            public static final String PAYLOAD_TYPE = "payloadType";
+        }
+
+        public static class PayloadType
+        {
+            public static final String SQL = "sql";
+            public static final String BROKER_REQUEST = "brokerRequest";
+        }
+    }
+
+    public static class Response
+    {
+        public static class MetadataKeys
+        {
+            public static final String RESPONSE_TYPE = "responseType";
+        }
+
+        public static class ResponseType
+        {
+            // For streaming response, multiple (could be 0 if no data should be returned, or query encounters exception)
+            // data responses will be returned, followed by one single metadata response
+            public static final String DATA = "data";
+            public static final String METADATA = "metadata";
+            // For non-streaming response
+            public static final String NON_STREAMING = "nonStreaming";
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/pinot/grpc/GrpcQueryClient.java
+++ b/src/main/java/com/facebook/presto/pinot/grpc/GrpcQueryClient.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot.grpc;
+
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
+import org.apache.pinot.common.proto.PinotQueryServerGrpc;
+import org.apache.pinot.common.proto.Server;
+
+import java.util.Iterator;
+
+public class GrpcQueryClient
+{
+    private final Channel channel;
+    private final PinotQueryServerGrpc.PinotQueryServerBlockingStub blockingStub;
+
+    public GrpcQueryClient(String host, int port, PinotStreamingQueryClient.Config config)
+    {
+        ManagedChannelBuilder managedChannelBuilder = ManagedChannelBuilder
+                    .forAddress(host, port)
+                    .maxInboundMessageSize(config.getMaxInboundMessageSizeBytes());
+        if (config.isUsePlainText()) {
+            managedChannelBuilder.usePlaintext();
+        }
+        channel = managedChannelBuilder.build();
+        blockingStub = PinotQueryServerGrpc.newBlockingStub(channel);
+    }
+
+    public Iterator<ServerResponse> submit(GrpcRequestBuilder requestBuilder)
+    {
+        Iterator<Server.ServerResponse> iterator = blockingStub.submit(requestBuilder.build());
+        return new Iterator<ServerResponse>()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public ServerResponse next()
+            {
+                return ServerResponse.of(iterator.next());
+            }
+        };
+    }
+}

--- a/src/main/java/com/facebook/presto/pinot/grpc/GrpcRequestBuilder.java
+++ b/src/main/java/com/facebook/presto/pinot/grpc/GrpcRequestBuilder.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot.grpc;
+
+import com.facebook.presto.pinot.PinotScatterGatherQueryClient;
+import org.apache.pinot.common.proto.Server;
+import org.apache.pinot.common.request.BrokerRequest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GrpcRequestBuilder
+{
+    private int requestId;
+    private String brokerId = "unknown";
+    private boolean enableTrace;
+    private boolean enableStreaming;
+    private String payloadType;
+    private String sql;
+    private BrokerRequest brokerRequest;
+    private List<String> segments;
+
+    public GrpcRequestBuilder setRequestId(int requestId)
+    {
+        this.requestId = requestId;
+        return this;
+    }
+
+    public GrpcRequestBuilder setBrokerId(String brokerId)
+    {
+        this.brokerId = brokerId;
+        return this;
+    }
+
+    public GrpcRequestBuilder setEnableTrace(boolean enableTrace)
+    {
+        this.enableTrace = enableTrace;
+        return this;
+    }
+
+    public GrpcRequestBuilder setEnableStreaming(boolean enableStreaming)
+    {
+        this.enableStreaming = enableStreaming;
+        return this;
+    }
+
+    public GrpcRequestBuilder setSql(String sql)
+    {
+        payloadType = Constants.Request.PayloadType.SQL;
+        this.sql = sql;
+        return this;
+    }
+
+    public GrpcRequestBuilder setBrokerRequest(BrokerRequest brokerRequest)
+    {
+        payloadType = Constants.Request.PayloadType.BROKER_REQUEST;
+        this.brokerRequest = brokerRequest;
+        return this;
+    }
+
+    public GrpcRequestBuilder setSegments(List<String> segments)
+    {
+        this.segments = segments;
+        return this;
+    }
+
+    public Server.ServerRequest build()
+    {
+        if (payloadType == null || segments.isEmpty()) {
+            throw new PinotScatterGatherQueryClient.PinotException(PinotScatterGatherQueryClient.ErrorCode.PINOT_UNCLASSIFIED_ERROR, "Query and segmentsToQuery must be set");
+        }
+        if (!payloadType.equals(Constants.Request.PayloadType.SQL)) {
+            throw new RuntimeException("Only [SQL] Payload type is allowed: " + payloadType);
+        }
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(Constants.Request.MetadataKeys.REQUEST_ID, Integer.toString(requestId));
+        metadata.put(Constants.Request.MetadataKeys.BROKER_ID, brokerId);
+        metadata.put(Constants.Request.MetadataKeys.ENABLE_TRACE, Boolean.toString(enableTrace));
+        metadata.put(Constants.Request.MetadataKeys.ENABLE_STREAMING, Boolean.toString(enableStreaming));
+        metadata.put(Constants.Request.MetadataKeys.PAYLOAD_TYPE, payloadType);
+        return Server.ServerRequest.newBuilder()
+                .putAllMetadata(metadata)
+                .setSql(sql)
+                .addAllSegments(segments)
+                .build();
+    }
+}

--- a/src/main/java/com/facebook/presto/pinot/grpc/PinotStreamingQueryClient.java
+++ b/src/main/java/com/facebook/presto/pinot/grpc/PinotStreamingQueryClient.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot.grpc;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Grpc based Pinot query client.
+ */
+public class PinotStreamingQueryClient
+{
+    private final Map<String, GrpcQueryClient> grpcQueryClientMap = new HashMap<>();
+    private final Config config;
+
+    public PinotStreamingQueryClient(Config config)
+    {
+        this.config = config;
+    }
+
+    public Iterator<ServerResponse> submit(String host, int port, GrpcRequestBuilder requestBuilder)
+    {
+        GrpcQueryClient client = getOrCreateGrpcQueryClient(host, port);
+        return client.submit(requestBuilder);
+    }
+
+    private GrpcQueryClient getOrCreateGrpcQueryClient(String host, int port)
+    {
+        String key = String.format("%s_%d", host, port);
+        if (!grpcQueryClientMap.containsKey(key)) {
+            grpcQueryClientMap.put(key, new GrpcQueryClient(host, port, config));
+        }
+        return grpcQueryClientMap.get(key);
+    }
+
+    public static class Config
+    {
+        // Default max message size to 128MB
+        private static final int DEFAULT_MAX_INBOUND_MESSAGE_BYTES_SIZE = 128 * 1024 * 1024;
+        private final int maxInboundMessageSizeBytes;
+        private final boolean usePlainText;
+
+        public Config()
+        {
+            this(DEFAULT_MAX_INBOUND_MESSAGE_BYTES_SIZE, false);
+        }
+
+        public Config(int maxInboundMessageSizeBytes, boolean usePlainText)
+        {
+            this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
+            this.usePlainText = usePlainText;
+        }
+
+        public int getMaxInboundMessageSizeBytes()
+        {
+            return maxInboundMessageSizeBytes;
+        }
+
+        public boolean isUsePlainText()
+        {
+            return usePlainText;
+        }
+    }
+}

--- a/src/main/java/com/facebook/presto/pinot/grpc/ServerResponse.java
+++ b/src/main/java/com/facebook/presto/pinot/grpc/ServerResponse.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot.grpc;
+
+import org.apache.pinot.common.proto.Server;
+import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.common.datatable.DataTableFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ * A wrapper class for org.apache.pinot.common.proto.Server.ServerResponse to simplify the usage of a proto generated class.
+ *
+ */
+public class ServerResponse
+{
+    private final Server.ServerResponse serverResponse;
+
+    public ServerResponse(Server.ServerResponse serverResponse)
+    {
+        this.serverResponse = serverResponse;
+    }
+
+    public DataTable getDataTable(ByteBuffer byteBuffer) throws IOException
+    {
+        return DataTableFactory.getDataTable(byteBuffer);
+    }
+
+    public String getResponseType()
+    {
+        return serverResponse.getMetadataMap().get(Constants.Response.MetadataKeys.RESPONSE_TYPE);
+    }
+
+    public byte[] getPayload()
+    {
+        return serverResponse.getPayload().toByteArray();
+    }
+
+    public ByteBuffer getPayloadReadOnlyByteBuffer()
+    {
+        return serverResponse.getPayload().asReadOnlyByteBuffer();
+    }
+
+    public Map<String, String> getMetadataMap()
+    {
+        return serverResponse.getMetadataMap();
+    }
+
+    public int getSerializedSize()
+    {
+        return serverResponse.getSerializedSize();
+    }
+
+    public static ServerResponse of(Server.ServerResponse response)
+    {
+        return new ServerResponse(response);
+    }
+}


### PR DESCRIPTION
- Update pinot libs to pinot release version 0.5.0 to simplify the code. 
- Add Pinot GRPC client for server queries.

Below are the major changes brought in with the upgrade.
1. `pinot-transport` package is merged into `pinot-core` and the scatter-gather logics are wrapped up into class `org.apache.pinot.core.transport.QueryRouter`, so we can directly use that for Server level queries.
2. More APIs  are brought in e.g. Pinot Routing table APIs, Server Streaming query APIs, which we can wrap them up and expose them to presto-pinot-toolkit.
3. This same lib should be common and potentially also be used by other projects which requires server/segment level access.

