### PR TITLE
Upgrade pinot version to 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <shadeBase>org.apache.pinot.\$internal</shadeBase>
-        <dep.pinot.version>0.5.0</dep.pinot.version>
-        <dep.helix.version>0.9.7</dep.helix.version>
+        <dep.pinot.version>0.8.0</dep.pinot.version>
+        <dep.helix.version>0.9.8</dep.helix.version>
         <log4j.version>2.11.2</log4j.version>
     </properties>
 
@@ -110,6 +110,10 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -193,6 +197,10 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -288,6 +296,10 @@
                 </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
                 <exclusion>
@@ -319,6 +331,12 @@
                     <artifactId>lucene-analyzers-common</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.pinot</groupId>
+            <artifactId>pinot-yammer</artifactId>
+            <version>${dep.pinot.version}</version>
         </dependency>
 
         <dependency>
@@ -395,11 +413,6 @@
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.yammer.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/facebook/presto/pinot/PinotScatterGatherQueryClient.java
+++ b/src/main/java/com/facebook/presto/pinot/PinotScatterGatherQueryClient.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.pinot;
 
-import com.yammer.metrics.core.MetricsRegistry;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
@@ -22,6 +21,7 @@ import org.apache.pinot.core.transport.AsyncQueryResponse;
 import org.apache.pinot.core.transport.QueryRouter;
 import org.apache.pinot.core.transport.ServerResponse;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.plugin.metrics.yammer.YammerMetricsRegistry;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.config.table.TableType;
@@ -45,7 +45,6 @@ public class PinotScatterGatherQueryClient
 {
     private static final Pql2Compiler REQUEST_COMPILER = new Pql2Compiler();
     private static final String PRESTO_HOST_PREFIX = "presto-pinot-";
-    private static final boolean DEFAULT_EMIT_TABLE_LEVEL_METRICS = true;
 
     private final String prestoHostId;
     private final BrokerMetrics brokerMetrics;
@@ -150,9 +149,7 @@ public class PinotScatterGatherQueryClient
     public PinotScatterGatherQueryClient(Config pinotConfig)
     {
         prestoHostId = getDefaultPrestoId();
-
-        MetricsRegistry registry = new MetricsRegistry();
-        brokerMetrics = new BrokerMetrics(registry, DEFAULT_EMIT_TABLE_LEVEL_METRICS);
+        brokerMetrics = new BrokerMetrics(new YammerMetricsRegistry());
         brokerMetrics.initializeGlobalMeters();
 
         // Setup QueryRouters


### PR DESCRIPTION
- Upgrade pinot version to 0.8.0
  - Support new Pinot DataTable v3/v4, which is the intermediate data structure.
  - Use new PinotMetrics constructor.
- Upgrade helix version to 0.9.8