### PR TITLE
Upgrade pinot version to 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <shadeBase>org.apache.pinot.\$internal</shadeBase>
-        <dep.pinot.version>0.5.0</dep.pinot.version>
-        <dep.helix.version>0.9.7</dep.helix.version>
+        <dep.pinot.version>0.8.0</dep.pinot.version>
+        <dep.helix.version>0.9.8</dep.helix.version>
         <log4j.version>2.11.2</log4j.version>
     </properties>
 
@@ -76,16 +76,16 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.reflections</groupId>
+                    <artifactId>reflections</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.antlr</groupId>
@@ -113,15 +113,15 @@
                 </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>javax.validation</groupId>
                     <artifactId>validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>joda-time</groupId>
@@ -151,6 +151,10 @@
                     <artifactId>checker-compat-qual</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.reflections</groupId>
+                    <artifactId>reflections</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
@@ -161,10 +165,6 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.antlr</groupId>
@@ -193,6 +193,10 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -259,10 +263,6 @@
                     <artifactId>log4j</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr4-annotations</artifactId>
                 </exclusion>
@@ -285,6 +285,10 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -322,6 +326,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.pinot</groupId>
+            <artifactId>pinot-yammer</artifactId>
+            <version>${dep.pinot.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.helix</groupId>
             <artifactId>helix-core</artifactId>
             <version>${dep.helix.version}</version>
@@ -337,10 +347,6 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.antlr</groupId>
@@ -397,14 +403,20 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.yammer.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>2.2.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.9</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -480,6 +492,7 @@
                                     <include>org.apache.http:*</include>
                                     <include>org.antlr:*</include>
                                     <include>org.apache.thrift:*</include>
+                                    <include>org.reflections:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -523,6 +536,10 @@
                                 <relocation>
                                     <pattern>com.yammer</pattern>
                                     <shadedPattern>${shadeBase}.com.yammer</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.reflections</pattern>
+                                    <shadedPattern>${shadeBase}.org.reflections</shadedPattern>
                                 </relocation>
                             </relocations>
                             <!-- exclude signed Manifests -->


### PR DESCRIPTION
- Upgrade pinot version to 0.8.0
  - Support new Pinot DataTable v3/v4, which is the intermediate data structure.
  - Use new PinotMetrics constructor.
- Upgrade helix version to 0.9.8
- Shade org.relections/guava/commons-logging libs to `org.apache.pinot$internal` to init the BrokerMetrics.
- Adding TlsConfig options for client configs