### PR TITLE
Adding maven enforce plugin to ignore bytecode warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -610,6 +610,36 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                    <executions>
+                        <execution>
+                            <id>default</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <enforceBytecodeVersion>
+                                        <ignoreClasses>
+                                            <ignoreClass>module-info.class</ignoreClass>
+                                            <ignoreClass>META-INF/versions/11/org/roaringbitmap/ArraysShim</ignoreClass>
+                                        </ignoreClasses>
+                                    </enforceBytecodeVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>extra-enforcer-rules</artifactId>
+                            <version>1.3</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This is to suppress jdk11 pinot jars class bytecode