### PR TITLE
Adding repo deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # presto-pinot-driver
+
+This repo is deprecated.
+
+Moved to `presto-pinot-driver` module in [Apache Pinot](https://github.com/apache/pinot/tree/master/pinot-connectors/presto-pinot-driver) repo.
+


### PR DESCRIPTION
Adding repo deprecation message, this repo is moved to Apache Pinot Repo: https://github.com/apache/pinot/tree/master/pinot-connectors/presto-pinot-driver